### PR TITLE
STUD-1290 Release Fixing version to match workiva convention

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.anaplan.client</groupId>
     <artifactId>anaplan-connect</artifactId>
-    <version>1.4.5-SNAPSHOT</version>
+    <version>1.4.5</version>
     <name>Anaplan Connect</name>
 
     <properties>


### PR DESCRIPTION
## Purpose

This PR addresses STUD-1290. The version was hardcoded and not being automatically increased, which means that future releases would have the same version 😬 

## Solution

The solution is to configure Rosie's settings to tag and release on every merge to master. This follows Workiva convention, and also allows us to auto increment the version every time a merge is made.

## Semantic Versioning (check one)

- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
    - *[link to the breaking change in the diff]*
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [x] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
  release

## How to QA

- [ ] run the following related examples: **(fill in)**
- [ ] Other necessary steps needed to fully exercise the solution should be added here. **(fill in)**
