### PR TITLE
STUD-2766: Changing categoryValues field in the ModelData object to also accept arbitrary JSON objects from the server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 .idea/
+.vscode/
 anaplan-connect.iml
 
 *.cer

--- a/java/src/main/java/com/anaplan/client/dto/ModelData.java
+++ b/java/src/main/java/com/anaplan/client/dto/ModelData.java
@@ -13,7 +13,7 @@ public class ModelData extends NamedObjectData {
     private String currentWorkspaceId;
     private String currentWorkspaceName;
     private String modelUrl;
-    private String[] categoryValues;
+    private Object[] categoryValues;
     public Long lastSavedSerialNumber;
     public String lastModifiedByUserGuid;
     public Long memoryUsage;
@@ -79,11 +79,11 @@ public class ModelData extends NamedObjectData {
         this.modelUrl = modelUrl;
     }
 
-    public String[] getCategoryValues() {
+    public Object[] getCategoryValues() {
         return categoryValues;
     }
 
-    public void setCategoryValues(String[] categoryValues) {
+    public void setCategoryValues(Object[] categoryValues) {
         this.categoryValues = categoryValues;
     }
 
@@ -135,7 +135,7 @@ public class ModelData extends NamedObjectData {
         ModelData data = (ModelData) other;
         return id.equals(data.id);
     }
-    
+
     @Override
     public int hashCode() {
         return id.hashCode();

--- a/java/src/test/java/com/anaplan/client/CategoryValuesTest.java
+++ b/java/src/test/java/com/anaplan/client/CategoryValuesTest.java
@@ -1,0 +1,23 @@
+package com.anaplan.client;
+
+import com.anaplan.client.dto.ModelData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+public class CategoryValuesTest {
+    private static final String OBJECT_CATEGORY_VALUES = "{ \"id\": \"id1\", \"name\": \"TestModel1\", \"activeState\": \"MAINTENANCE\", \"lastSavedSerialNumber\": 50302010, \"lastModifiedByUserGuid\": \"guid1\", \"memoryUsage\": 12345, \"currentWorkspaceId\": \"guid2\", \"currentWorkspaceName\": \"Workspace\", \"modelUrl\": \"https://my.anaplan.com/anaplan/framework.jsp?selectedWorkspaceId=guid2&selectedModelId=id1\", \"categoryValues\": [ { \"id\": \"id2\", \"attribute\": \"Office Supplies\", \"categoryId\": \"id3\", \"categoryName\": \"Etcetera\", \"customerId\": \"id4\" } ], \"isoCreationDate\": \"2020-01-01T00:00:00.000+0000\", \"lastModified\": \"2020-01-01T00:00:00.000+0000\" }";
+    private static final String STRING_CATEGORY_VALUES = "{ \"id\": \"id1\", \"name\": \"TestModel1\", \"activeState\": \"MAINTENANCE\", \"lastSavedSerialNumber\": 50302010, \"lastModifiedByUserGuid\": \"guid1\", \"memoryUsage\": 12345, \"currentWorkspaceId\": \"guid2\", \"currentWorkspaceName\": \"Workspace\", \"modelUrl\": \"https://my.anaplan.com/anaplan/framework.jsp?selectedWorkspaceId=guid2&selectedModelId=id1\", \"categoryValues\": [ \"Testing\" ], \"isoCreationDate\": \"2020-01-01T00:00:00.000+0000\", \"lastModified\": \"2020-01-01T00:00:00.000+0000\" }";
+
+    @Test()
+    public void modelDataAllowsRandomObjectsForCategoryValues() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.readValue(OBJECT_CATEGORY_VALUES, ModelData.class);
+    }
+
+    @Test()
+    public void modelDataAllowsStringsForCategoryValues() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.readValue(STRING_CATEGORY_VALUES, ModelData.class);
+    }
+}


### PR DESCRIPTION
## Purpose
We had an issue with a client summarized in https://jira.atl.workiva.net/browse/SUPP-57614.

Long story short, we added a customization to our forked version of the anaplan-client repo that allowed users to get back "categoryValue" data from the api. At one point in time, these categoryValue data were just strings. Anaplan now allows them to be objects. This is breaking the deserialization for our current implementation that only expects strings.

The customizations were originally made here: https://github.com/Workiva/anaplan-java-client/pull/7

## Solution
We now allow the ModelData objects to accept arbitrary JSON objects.

## Semantic Versioning (check one)

- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
    - *[link to the breaking change in the diff]*
- [x] Something public was added or changed in backward compatible way, this requires a minor version bump
- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
  release

## How to QA

- [ ] run the following related examples: **(fill in)**
- [x] Other necessary steps needed to fully exercise the solution should be added here. **The unit tests should now cover this**
