### PR TITLE
STUD-2407: updating aconnect header to custom workiva value

### DIFF
--- a/java/src/main/java/com/anaplan/client/Constants.java
+++ b/java/src/main/java/com/anaplan/client/Constants.java
@@ -17,7 +17,7 @@ public class Constants {
     public static final Integer AUTH_TTL_SECONDS = 30;
 
     public static final String X_ACONNECT_HEADER_KEY = "X-AConnect-Client";
-    public static final String X_ACONNECT_HEADER_VALUE = "Anaplan_Connect_1.4.4";
+    public static final String X_ACONNECT_HEADER_VALUE = "Workiva_Anaplan_Connect_v1.4.x";
     public static final String X_ACONNECT_HEADER = X_ACONNECT_HEADER_KEY + ":" + X_ACONNECT_HEADER_VALUE;
 
     public static final String CORS_HEADER_KEY = "Origin";

--- a/java/src/main/java/com/anaplan/client/Constants.java
+++ b/java/src/main/java/com/anaplan/client/Constants.java
@@ -17,7 +17,7 @@ public class Constants {
     public static final Integer AUTH_TTL_SECONDS = 30;
 
     public static final String X_ACONNECT_HEADER_KEY = "X-AConnect-Client";
-    public static final String X_ACONNECT_HEADER_VALUE = "Workiva_Anaplan_Connect_v1.4.x";
+    public static final String X_ACONNECT_HEADER_VALUE = "Workiva_Anaplan_Connect_v3";
     public static final String X_ACONNECT_HEADER = X_ACONNECT_HEADER_KEY + ":" + X_ACONNECT_HEADER_VALUE;
 
     public static final String CORS_HEADER_KEY = "Origin";


### PR DESCRIPTION
## Purpose

Updating the aconnect version header to a custom workiva value so that anaplan may capture it and provide analytics about how workiva users use their API via chains.

relevant STUD: https://jira.atl.workiva.net/browse/STUD-2407 

## Solution
Update the header to `Workiva_Anaplan_Connect_v1.4.x`

## Semantic Versioning (check one)

- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
    - *[link to the breaking change in the diff]*
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [x] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
  release

## How to QA

- [x] run the following related examples:
- [ ] update the bizapp to use this change
- [ ] verify that with this change, the bizapp sends requests to the Anaplan API with the updated header
