### PR TITLE
STUD-5918: Add access token authentication

### DIFF
--- a/java/src/main/java/com/anaplan/client/auth/AccessTokenAuthenticator.java
+++ b/java/src/main/java/com/anaplan/client/auth/AccessTokenAuthenticator.java
@@ -1,0 +1,19 @@
+package com.anaplan.client.auth;
+
+import com.anaplan.client.transport.ConnectionProperties;
+
+import java.nio.charset.StandardCharsets;
+
+public class AccessTokenAuthenticator extends AbstractAuthenticator {
+    private final ConnectionProperties properties;
+
+    AccessTokenAuthenticator(ConnectionProperties properties) {
+        super(properties);
+        this.properties = properties;
+    }
+
+    @Override
+    public byte[] authenticate() {
+        return this.properties.getApiCredentials().getAccessToken().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/java/src/main/java/com/anaplan/client/auth/AuthenticatorFactory.java
+++ b/java/src/main/java/com/anaplan/client/auth/AuthenticatorFactory.java
@@ -17,6 +17,8 @@ public class AuthenticatorFactory {
                 return new BasicAuthenticator(properties);
             case CA_CERTIFICATE:
                 return new CertificateAuthenticator(properties);
+            case ACCESS_TOKEN:
+                return new AccessTokenAuthenticator(properties);
             default:
                 throw new RuntimeException("Unknown authentication scheme: " + properties.getApiCredentials().getScheme());
         }

--- a/java/src/main/java/com/anaplan/client/auth/Credentials.java
+++ b/java/src/main/java/com/anaplan/client/auth/Credentials.java
@@ -127,7 +127,8 @@ public final class Credentials {
     public String getPassPhrase() {
 return passPhrase;
     }
-        public String getAccessToken() {
+
+    public String getAccessToken() {
             return accessToken;
         }
 

--- a/java/src/main/java/com/anaplan/client/auth/Credentials.java
+++ b/java/src/main/java/com/anaplan/client/auth/Credentials.java
@@ -27,7 +27,8 @@ public final class Credentials {
     public enum Scheme {
         BASIC,
         NTLM,
-        CA_CERTIFICATE
+        CA_CERTIFICATE,
+        ACCESS_TOKEN
     }
 
     private Scheme scheme;
@@ -36,6 +37,8 @@ public final class Credentials {
     private String passPhrase;
     private String domain;
     private String workstation;
+
+    private String accessToken;
 
     private X509Certificate certificate;
     private RSAPrivateKey privateKey;
@@ -53,6 +56,17 @@ public final class Credentials {
         this.domain = workstation = null;
         this.certificate = null;
         this.scheme = Scheme.BASIC;
+    }
+
+    /**
+     * Use pre-authed access token for authentication method. Obtained through
+     * <a href="https://anaplanoauth2service.docs.apiary.io/#reference/overview-of-the-authorization-code-grant">this method.</a>
+     *
+     * @param accessToken   The access token from the auth code Oauth2 handshake.
+     */
+    public Credentials(String accessToken) {
+        this.accessToken = accessToken;
+        this.scheme = Scheme.ACCESS_TOKEN;
     }
 
     /**
@@ -111,8 +125,11 @@ public final class Credentials {
      * Get the passPhrase.
      */
     public String getPassPhrase() {
-        return passPhrase;
+return passPhrase;
     }
+        public String getAccessToken() {
+            return accessToken;
+        }
 
     /**
      * Get the domain. This is only used when accessing the service through a

--- a/java/src/main/java/com/anaplan/client/auth/Credentials.java
+++ b/java/src/main/java/com/anaplan/client/auth/Credentials.java
@@ -125,12 +125,12 @@ public final class Credentials {
      * Get the passPhrase.
      */
     public String getPassPhrase() {
-return passPhrase;
+        return passPhrase;
     }
 
     public String getAccessToken() {
-            return accessToken;
-        }
+        return accessToken;
+    }
 
     /**
      * Get the domain. This is only used when accessing the service through a

--- a/java/src/test/java/com/anaplan/client/auth/AccessTokenAuthenticatorTest.java
+++ b/java/src/test/java/com/anaplan/client/auth/AccessTokenAuthenticatorTest.java
@@ -1,0 +1,20 @@
+package com.anaplan.client.auth;
+
+import com.anaplan.client.transport.ConnectionProperties;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class AccessTokenAuthenticatorTest {
+    @Test
+    public void testAccessTokenAuthenticatorReturnsAccessToken() throws IOException {
+        final ConnectionProperties props = new ConnectionProperties();
+        props.setApiCredentials(new Credentials("my_access_token"));
+
+        final Authenticator authenticator = AuthenticatorFactory.getAuthenticator(props);
+
+        Assert.assertArrayEquals("my_access_token".getBytes(StandardCharsets.UTF_8), authenticator.authenticate());
+    }
+}


### PR DESCRIPTION
## Purpose

We need to be able to auth with an access token provided by the auth code oauth2 flow.

When researching this ticket, the first thing that _seemed_ to make sense was to update our library to use the [v4 version of the Anaplan client library](https://github.com/anaplaninc/anaplan-java-client). This would have been a big version jump. Additionally, we would need to verify that our additions to this library were carried over to v4. I [attempted to use the v4 version of the library](https://github.com/Workiva/anaplan-java-client/tree/v4) and made some changes that seemed to add all the features of our forked version to the Anaplan maintained client. The idea was going to be "killing two birds with one stone" (namely, I update the client, and submit my changes to the main repo, and we get rid of our fork in the process). Unfortunately, even after my changes, we were still lacking things from v4.

First and foremost, I cannot get a response from the anaplan team to see if they would be willing to accept my contributions: https://github.com/anaplaninc/anaplan-java-client/issues/47

Because we are locked out of contributing code to their repo, we cannot add the changes we need. I attempted to use vanillag v4 as it stands, but it does not allow for us to "`extend`" the functionality that we need in our anaplan connector (i.e. subclass the types and add the functionality we desire)... For example, internally, the Anaplan client does not capture every field that is returned by the API in their Java objects, so there is a loss of information before we can even start "extending" the domain models. We rely on some of this information they do not capture (again, see the Github issue I linked above).

Finally v4 does not support the oauth2 auth code authentication model. It appeared to at first glance, but this was the oauth2 device code model.

Therefore, the most straightforward solution was implementing it ourselves. If Anaplan ever gets back to us, we can hopefully contribute some of this work and get off the fork, because, after my research, some of the changes appear to be minimal.

## Solution

Add a new authenticator that accepts a token that is passed in through the command line.

## Semantic Versioning (check one)

- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
    - *[link to the breaking change in the diff]*
- [x] Something public was added or changed in backward compatible way, this requires a minor version bump
- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch
  release

## How to QA

- [x] run the following related examples: Will need the corresponding mechanism in the anaplan connector. For now, the unit test will have to suffice.
- [ ] Other necessary steps needed to fully exercise the solution should be added here. **(fill in)**
